### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ $> Rscript legacy_Data_sempling_topic_modeling.r
 
 ## Additional Documentation
 
-- [Running python notebook on Data](python-notebook/Run_LLM_on_server_how_to.md) - Instructions for running large language models for topic modeling.
+- [Running python notebook on Data](python-notebooks/Run_LLM_on_server_how_to.md) - Instructions for running large language models for topic modeling.


### PR DESCRIPTION
# Description:
minor fixing of documentation file in README

# Demonstration:

<img width="701" alt="image" src="https://github.com/user-attachments/assets/c31f27e3-21b9-4a14-84b5-fed637e34781" />
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/f80e6a43-1d5d-47a7-bad9-b6baeec28e16" />
